### PR TITLE
Added Jekyll template for more readable feature descriptions

### DIFF
--- a/_includes/feature-detail.html
+++ b/_includes/feature-detail.html
@@ -1,0 +1,15 @@
+{% if include.justify | downcase == "right" %}
+<section class="features-reversedsection">
+{% else %}
+<section>
+{% endif %}
+  <div class="features-featurecontainer">
+    <div class="features-imagecontainer">
+      <img src="{{ include.img }}" alt="{{ include.img_alt }}" class="features-featureimage"/>
+    </div>
+    <div class="features-textcontainer">
+      <h3 class="h3">{{ include.title }}</h3>
+      {{ include.detail | strip | markdownify }}
+    </div>
+  </div>
+</section>

--- a/_sass/_features.scss
+++ b/_sass/_features.scss
@@ -89,6 +89,15 @@
   width: 100%;
   max-width: 530px;
   flex-shrink: 1;
+
+  a {
+    @extend .intext-link;
+    @extend .intext-link-glow;
+  }
+
+  p {
+    @extend .p-body;
+  }
 }
 
 .features-reversedsection {

--- a/site_collections/_features/2d-compositing.html
+++ b/site_collections/_features/2d-compositing.html
@@ -4,81 +4,34 @@ title: 2D Compositing
 excerpt: text
 collection: features
 ---
-<section>
-  <div class="features-featurecontainer">
-    <div class="features-imagecontainer">
-      <img src="https://picsum.photos/1280/720" alt="" class="features-featureimage"/>
-    </div>
-    <div class="features-textcontainer">
-      <h3 class="h3">2D Tracking</h3>
-      <p class="p-body">
-        Track difficult movements with ease!
-        <br />
-        <br />
-        Natron's tracker can handle and correct a variety of footage types with single point or perspective tracking. Luminance variation correction and manual keyframes ensure get solid tracks even in tricky shots.
-      </p>
-    </div>
-  </div>
-</section>
 
-<section class="features-reversedsection">
-  <div class="features-featurecontainer">
-    <div class="features-imagecontainer">
-      <img src="../../img/feature-images/feature-roto.jpg" alt="A soldier firing a rifle, in half the image the soldier has been isolated from the background." class="features-featureimage"/>
-    </div>
-    <div class="features-textcontainer">
-      <h3 class="h3">Rotoscoping</h3>
-      <p class="p-body">
-        Mask, feather, repeat!
-        <br />
-        <br />
-        Natronʼs rotoscope node allows you to capture sub-pixel details. Each roto point has individual controls for feathering, allowing compositors to capture plate motion blur in different areas of each roto-shape. Roto shapes can be tracked for faster results.
-      </p>
-    </div>
-  </div>
-</section>
+{% include feature-detail.html
+   title="2D Tracking"
+   img="https://picsum.photos/1280/720"
+   img_alt=""
+   detail="
+    Track difficult movements with ease!
+    <br />
+    <br />
+    Natron's tracker can handle and correct a variety of footage types with single point or perspective tracking. Luminance variation correction and manual keyframes ensure get solid tracks even in tricky shots."
+%}
 
-<section>
-  <div class="features-featurecontainer">
-    <div class="features-imagecontainer">
-      <img src="https://picsum.photos/1280/720" alt="" class="features-featureimage"/>
-    </div>
-    <div class="features-textcontainer">
-      <h3 class="h3">Keying</h3>
-      <p class="p-body">
-        Natron provides a wide range of keyers to assist in extracting mattes from images. The familiar Additive, Chroma, and Hue keyers are built-in, as well as Natron's own powerful PIK keyer. Tools for refining matte edges and color edges allow you you to achieve professional results.
-      </p>
-    </div>
-  </div>
-</section>
+{% include feature-detail.html
+   title="Paint"
+   img="https://picsum.photos/1280/720"
+   img_alt=""
+   justify="right"
+   detail="
+    Remove objects, clone backgrounds, and fix it in post!
+    <br />
+    <br />
+    Natron features a vector-based RotoPaint node, making tasks like object removal, dust removal, and creating garbage mattes a breeze. Paint strokes are available for a variety of brushes. Additionally, per-point and global feather, motion blur, blending modes and individual or hierarchical 2D transformations are fully supported."
+%}
 
-<!-- <section class="features-reversedsection">
-  <div class="features-featurecontainer">
-    <div class="features-imagecontainer">
-      <img src="https://picsum.photos/1280/720" alt="" class="features-featureimage"/>
-    </div>
-    <div class="features-textcontainer">
-      <h3 class="h3">Paint</h3>
-      <p class="p-body">
-        Remove objects, clone backgrounds, and fix it in post!
-        <br />
-        <br />
-        Natron features a vector-based RotoPaint node, making tasks like object removal, dust removal, and creating garbage mattes a breeze. Paint strokes are available for a variety of brushes. Additionally, per-point and global feather, motion blur, blending modes and individual or hierarchical 2D transformations are fully supported.
-      </p>
-    </div>
-  </div>
-</section> -->
-
-<section class="features-reversedsection">
-  <div class="features-featurecontainer">
-    <div class="features-imagecontainer">
-      <img src="https://picsum.photos/1280/720" alt="" class="features-featureimage"/>
-    </div>
-    <div class="features-textcontainer">
-      <h3 class="h3">Animation</h3>
-      <p class="p-body">
-        Natron offers a simple and efficient way to manage keyframes with an accurate and intuitive curve editor. You can set expressions on animation curves to create fluid, believable motion for objects. Natron also incorporates a fully featured dope-sheet to view all animations at a glance, or to quickly edit clips and keyframes.
-      </p>
-    </div>
-  </div>
-</section>
+{% include feature-detail.html
+   title="Animation"
+   img="https://picsum.photos/1280/720"
+   img_alt=""
+   detail="
+    Natron offers a simple and efficient way to manage keyframes with an accurate and intuitive curve editor. You can set expressions on animation curves to create fluid, believable motion for objects. Natron also incorporates a fully featured dope-sheet to view all animations at a glance, or to quickly edit clips and keyframes."
+%}

--- a/site_collections/_features/cg-compositing.html
+++ b/site_collections/_features/cg-compositing.html
@@ -4,33 +4,23 @@ title: CG Compositing
 excerpt: text
 collection: features
 ---
-<section>
-  <div class="features-featurecontainer">
-    <div class="features-imagecontainer">
-      <img src="https://picsum.photos/1280/720" alt="" class="features-featureimage"/>
-    </div>
-    <div class="features-textcontainer">
-      <h3 class="h3">Multi-Channel EXR Support</h3>
-      <p class="p-body">
-        Take advantage of nearly every pass that comes out of your renderer of choice! Tweak certian chanels from your renders to match plates, or use them to create unique stylized looks as part of your CG compositing process.
-      </p>
-      <p class="p-body">
-        Natron does not currently support deep image compositing.
-      </p>
-    </div>
-  </div>
-</section>
 
-<section class="features-reversedsection">
-  <div class="features-featurecontainer">
-    <div class="features-imagecontainer">
-      <img src="https://picsum.photos/1280/720" alt="" class="features-featureimage"/>
-    </div>
-    <div class="features-textcontainer">
-      <h3 class="h3">Stereo compositing</h3>
-      <p class="p-body">
-        Make eye-popping visual effects with Natron's built-in stereoscopic tools. You get all of Natron's 200+ typical nodes in a stereoscopic project, plus a variety of tools for working with multiple views and previewing stereo live in Natron.
-      </p>
-    </div>
-  </div>
-</section>
+{% include feature-detail.html
+   title="Multi-Channel EXR Support"
+   img="https://picsum.photos/1280/720"
+   img_alt=""
+   detail="
+    Take advantage of nearly every pass that comes out of your renderer of choice! Tweak certian chanels from your renders to match plates, or use them to create unique stylized looks as part of your CG compositing process.
+    <br />
+    <br />
+    Natron does not currently support deep image compositing."
+%}
+
+{% include feature-detail.html
+   title="Stereo compositing"
+   img="https://picsum.photos/1280/720"
+   img_alt=""
+   justify="right"
+   detail="
+    Make eye-popping visual effects with Natron's built-in stereoscopic tools. You get all of Natron's 200+ typical nodes in a stereoscopic project, plus a variety of tools for working with multiple views and previewing stereo live in Natron."
+%}

--- a/site_collections/_features/extensibility.html
+++ b/site_collections/_features/extensibility.html
@@ -35,10 +35,10 @@ collection: features
    title="PyPlugs"
    img="https://picsum.photos/1280/720"
    img_alt=""
-   justify="right"
    detail="
-    User-created custom nodes can be created visually within Natron by grouping existing nodes and exported with the "PyPlug" exporter.
-    
+    User-created custom nodes can be created visually within Natron by grouping existing nodes and exported with the \"PyPlug\" exporter.
+    <br />
+    <br />
     Various tools created by the commuity can be found in [Natron's community plugins repository](https://github.com/NatronGitHub/natron-plugins) on GitHub."
 %}
 

--- a/site_collections/_features/extensibility.html
+++ b/site_collections/_features/extensibility.html
@@ -4,89 +4,58 @@ title: Extensibility
 excerpt: text
 collection: features
 ---
-<section>
-  <div class="features-featurecontainer">
-    <div class="features-imagecontainer">
-      <img src="https://picsum.photos/1280/720" alt="" class="features-featureimage"/>
-    </div>
-    <div class="features-textcontainer">
-      <h3 class="h3">Expressions</h3>
-      <p class="p-body">
-        Link just about any two parameters with Natron's broad support for expressions. Automate your nodes with mathematical functions, and extend expressions with Python. Programmic commands not appealing to you? Natron also offers a GUI-based system for quickly linking any two controls, and expressions are visible within the curve editor.
-      </p>
-    </div>
-  </div>
-</section>
+{% include feature-detail.html
+   title="Expressions"
+   img="https://picsum.photos/1280/720"
+   img_alt=""
+   detail="
+    Link just about any two parameters with Natron's broad support for expressions. Automate your nodes with mathematical functions, and extend expressions with Python. Programmic commands not appealing to you? Natron also offers a GUI-based system for quickly linking any two controls, and expressions are visible within the curve editor."
+%}
 
-<section class="features-reversedsection">
-  <div class="features-featurecontainer">
-    <div class="features-imagecontainer">
-      <img src="https://picsum.photos/1280/720" alt="" class="features-featureimage"/>
-    </div>
-    <div class="features-textcontainer">
-      <h3 class="h3">Python API</h3>
-      <p class="p-body">
-        Make Natron your own with Natron's powerful scripting support. The Python API can be used for full pipeline integration and automating common tasks and procedures. PySide is also included to allow users to build custom user interfaces via Python and the Qt framework.
-      </p>
-    </div>
-  </div>
-</section>
+{% include feature-detail.html
+   title="Python API"
+   img="https://picsum.photos/1280/720"
+   img_alt=""
+   justify="right"
+   detail="
+    Make Natron your own with Natron's powerful scripting support. The Python API can be used for full pipeline integration and automating common tasks and procedures. PySide is also included to allow users to build custom user interfaces via Python and the Qt framework."
+%}
 
-<section>
-  <div class="features-featurecontainer">
-    <div class="features-imagecontainer">
-      <img src="../../img/feature-images/feature-ofx.png" alt="OpenFX Association logo" class="features-featureimage"/>
-    </div>
-    <div class="features-textcontainer">
-      <h3 class="h3">OpenFX Support</h3>
-      <p class="p-body">
-        Natron is compliant with the OpenFX standard, allowing you to tap into the vast ecosystem of commercial OFX plugins. Never worry about missing the functionality of your OFX plugins, with Natron's support for <a href="http://www.revisionfx.com" class="intext-link intext-link-glow">RevisionFX products</a>, <a href="https://www.neatvideo.com" class="intext-link intext-link-glow">NeatVideo denoiser</a>, <a href="http://www.thefoundry.co.uk/products/furnace/" class="intext-link intext-link-glow">Furnace by The Foundry</a>, <a href="http://www.thefoundry.co.uk/products/plugins/keylight/" class="intext-link intext-link-glow">KeyLight</a>, <a href="http://www.genarts.com/software/sapphire/overview" class="intext-link intext-link-glow">GenArts Sapphire</a>, <a href="http://www.redgiant.com/universe/" class="intext-link intext-link-glow">Red Giant Universe</a>, <a href="https://hitfilm.com/ignite" class="intext-link intext-link-glow">Ignite by HitFilm</a>, and many more!
-      </p>
-    </div>
-  </div>
-</section>
+{% include feature-detail.html
+   title="OpenFX Support"
+   img="../../img/feature-images/feature-ofx.png"
+   img_alt="OpenFX plugin standard logo"
+   justify="right"
+   detail="
+    Natron is compliant with the OpenFX standard, allowing you to tap into the vast ecosystem of commercial OFX plugins. Never worry about missing the functionality of your OFX plugins, with Natron's support for 
+    [RevisionFX products](http://www.revisionfx.com), [NeatVideo denoiser](https://www.neatvideo.com), [Furnace by The Foundry](http://www.thefoundry.co.uk/products/furnace/), [KeyLight](http://www.thefoundry.co.uk/products/plugins/keylight/), [GenArts Sapphire](http://www.genarts.com/software/sapphire/overview), [Red Giant Universe](http://www.redgiant.com/universe/), [Ignite by HitFilm](https://hitfilm.com/ignite), and many more!"
+%}
 
-<section class="features-reversedsection">
-  <div class="features-featurecontainer">
-    <div class="features-imagecontainer">
-      <img src="https://picsum.photos/1280/720" alt="" class="features-featureimage"/>
-    </div>
-    <div class="features-textcontainer">
-      <h3 class="h3">PyPlugs</h3>
-      <p class="p-body">
-        User-created custom nodes can be created visually within Natron by grouping existing nodes and exported with the "PyPlug" exporter.
-      </p>
-      <p class="p-body">
-        Various tools created by the commuity can be found in <a href="https://github.com/NatronGitHub/natron-plugins" class="intext-link intext-link-glow">Natron's community plugins repository</a> on GitHub.
-      </p>
-    </div>
-  </div>
-</section>
+{% include feature-detail.html
+   title="PyPlugs"
+   img="https://picsum.photos/1280/720"
+   img_alt=""
+   justify="right"
+   detail="
+    User-created custom nodes can be created visually within Natron by grouping existing nodes and exported with the "PyPlug" exporter.
+    
+    Various tools created by the commuity can be found in [Natron's community plugins repository](https://github.com/NatronGitHub/natron-plugins) on GitHub."
+%}
 
-<section>
-  <div class="features-featurecontainer">
-    <div class="features-imagecontainer">
-      <img src="../../img/feature-images/feature-shadertoy.png" alt="Shadertoy logo" class="features-featureimage"/>
-    </div>
-    <div class="features-textcontainer">
-      <h3 class="h3">Shadertoy Integration</h3>
-      <p class="p-body">
-        Make cinematic, high-performance, real-time effects with Natron's support for Shadertoy shaders. Create generative art and procedural effects using shadertoys, or use any shader found on <a href="https://www.shadertoy.com/" class="intext-link intext-link-glow">shadertoy.com</a> or <a href="https://cineshader.com/gallery" class="intext-link intext-link-glow">Cineshader</a>. Natron optimizes your shadertoys by outputting as 2D images to the graph, enabling you to use proxies for better performance.
-      </p>
-    </div>
-  </div>
-</section>
+{% include feature-detail.html
+   title="Shadertoy Integration"
+   img="../../img/feature-images/feature-shadertoy.png"
+   img_alt="Shadertoy WebGL shaders logo"
+   justify="right"
+   detail="
+    Make cinematic, high-performance, real-time effects with Natron's support for Shadertoy shaders. Create generative art and procedural effects using shadertoys, or use any shader found on [shadertoy.com](https://www.shadertoy.com/) or [Cineshader](https://cineshader.com/gallery). Natron optimizes your shadertoys by outputting as 2D images to the graph, enabling you to use proxies for better performance."
+%}
 
-<section class="features-reversedsection">
-  <div class="features-featurecontainer">
-    <div class="features-imagecontainer">
-      <img src="../../img/feature-images/feature-gmic.png" alt="GMIC logo" class="features-featureimage"/>
-    </div>
-    <div class="features-textcontainer">
-      <h3 class="h3">GMIC Integration</h3>
-      <p class="p-body">
-        Natron integrates with the G'MIC library, providing full-featured open-source image processing capabilities to Natron. More than 500 filters, effects, and retouching tools from G'MIC can be directly accessible from Natron, including color grades, artistic filters, deformations, patterns, shadows, and more!
-      </p>
-    </div>
-  </div>
-</section>
+{% include feature-detail.html
+   title="GMIC Integration"
+   img="../../img/feature-images/feature-gmic.png"
+   img_alt="GMIC image-processing plugins logo"
+   justify="right"
+   detail="
+    Natron integrates with the G'MIC library, providing full-featured open-source image processing capabilities to Natron. More than 500 filters, effects, and retouching tools from G'MIC can be directly accessible from Natron, including color grades, artistic filters, deformations, patterns, shadows, and more!"
+%}

--- a/site_collections/_features/extensibility.html
+++ b/site_collections/_features/extensibility.html
@@ -25,7 +25,6 @@ collection: features
    title="OpenFX Support"
    img="../../img/feature-images/feature-ofx.png"
    img_alt="OpenFX plugin standard logo"
-   justify="right"
    detail="
     Natron is compliant with the OpenFX standard, allowing you to tap into the vast ecosystem of commercial OFX plugins. Never worry about missing the functionality of your OFX plugins, with Natron's support for 
     [RevisionFX products](http://www.revisionfx.com), [NeatVideo denoiser](https://www.neatvideo.com), [Furnace by The Foundry](http://www.thefoundry.co.uk/products/furnace/), [KeyLight](http://www.thefoundry.co.uk/products/plugins/keylight/), [GenArts Sapphire](http://www.genarts.com/software/sapphire/overview), [Red Giant Universe](http://www.redgiant.com/universe/), [Ignite by HitFilm](https://hitfilm.com/ignite), and many more!"
@@ -35,6 +34,7 @@ collection: features
    title="PyPlugs"
    img="https://picsum.photos/1280/720"
    img_alt=""
+   justify="right"
    detail="
     User-created custom nodes can be created visually within Natron by grouping existing nodes and exported with the \"PyPlug\" exporter.
     <br />
@@ -46,7 +46,6 @@ collection: features
    title="Shadertoy Integration"
    img="../../img/feature-images/feature-shadertoy.png"
    img_alt="Shadertoy WebGL shaders logo"
-   justify="right"
    detail="
     Make cinematic, high-performance, real-time effects with Natron's support for Shadertoy shaders. Create generative art and procedural effects using shadertoys, or use any shader found on [shadertoy.com](https://www.shadertoy.com/) or [Cineshader](https://cineshader.com/gallery). Natron optimizes your shadertoys by outputting as 2D images to the graph, enabling you to use proxies for better performance."
 %}

--- a/site_collections/_features/pipeline.html
+++ b/site_collections/_features/pipeline.html
@@ -5,60 +5,42 @@ excerpt: text
 collection: features
 ---
 
-<section>
-  <div class="features-featurecontainer">
-    <div class="features-imagecontainer">
-      <img src="../../img/feature-images/feature-ocio.jpg" alt="The OCIO logo" class="features-featureimage"/>
-    </div>
-    <div class="features-textcontainer">
-      <h3 class="h3">OCIO Support</h3>
-      <p class="p-body">
-         OpenColorIO (OCIO), the open-source color management solution from Sony Picture Imageworks, is integrated into Natron's native color management system. With OCIO, Natron's profile produces consistent colors across all compatible applications, simplifying the color management process.
-      </p>
-    </div>
-  </div>
-</section>
+{% include feature-detail.html
+   title="OCIO Support"
+   img="../../img/feature-images/feature-ocio.jpg"
+   img_alt="OpenColorIO (OCIO) logo"
+   detail="
+    OpenColorIO (OCIO), the open-source color management solution from Sony Picture Imageworks, is integrated into Natron's native color management system. With OCIO, Natron's profile produces consistent colors across all compatible applications, simplifying the color management process."
+%}
 
-<section class="features-reversedsection">
-  <div class="features-featurecontainer">
-    <div class="features-imagecontainer">
-      <img src="../../img/feature-images/feature-headless-2.svg" alt="A log of Natron rendering in the terminal" class="features-featureimage"/>
-    </div>
-    <div class="features-textcontainer">
-      <h3 class="h3">Headless Rendering</h3>
-      <p class="p-body">
-        Natron projects can be rendered directly from the command line allowing you to harness the full power of your render farm, even with GPU acceleration.
-        <br /><br />
-        Render-farm integrations are readily available for <a href="https://cgru.readthedocs.io/en/latest/software/natron.html" class="intext-link intext-link-glow">Afanasy</a>, <a href="https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/app-natron.html?highlight=natron" class="intext-link intext-link-glow">Deadline</a>, and <a href="https://prism-pipeline.readthedocs.io/en/latest/index/feature_reference/#natron" class="intext-link intext-link-glow">Prism</a>.
-      </p>
-    </div>
-  </div>
-</section>
+{% include feature-detail.html
+   title="Headless Rendering"
+   img="../../img/feature-images/feature-headless-2.svg"
+   img_alt="A log of Natron rendering in the terminal"
+   justify="right"
+   detail="
+    Natron projects can be rendered directly from the command line allowing you to harness the full power of your render farm, even with GPU acceleration.
+    <br />
+    <br />
+    Render-farm integrations are readily available for [Afanasy](https://cgru.readthedocs.io/en/latest/software/natron.html), [Deadline](https://docs.thinkboxsoftware.com/products/deadline/10.1/1_User%20Manual/manual/app-natron.html?highlight=natron), and [Prism](https://prism-pipeline.readthedocs.io/en/latest/index/feature_reference/#natron)."
+%}
 
-<section>
-  <div class="features-featurecontainer">
-    <div class="features-imagecontainer">
-      <img src="../../img/feature-images/feature-opensource.jpg" alt="The open source logo" class="features-featureimage"/>
-    </div>
-    <div class="features-textcontainer">
-      <h3 class="h3">Free and Open Source</h3>
-      <p class="p-body">
-        Natron licensed under the GNU GPL license, and developed in the open entirely by the community. It is free software, and yours to keep forever! <br /><br /> Source code is available on <a href="https://github.com/NatronGitHub/Natron" class="intext-link intext-link-glow">GitHub</a>.
-      </p>
-    </div>
-  </div>
-</section>
+{% include feature-detail.html
+   title="Free and Open-Source"
+   img="../../img/feature-images/feature-opensource.jpg"
+   img_alt="The open-source logo"
+   detail="
+    Natron licensed under the GNU GPL license, and developed in the open entirely by the community. It is free software, and yours to keep forever!
+    <br />
+    <br />
+    Source code is available on [our GitHub](https://github.com/NatronGitHub/Natron)."
+%}
 
-<section class="features-reversedsection">
-  <div class="features-featurecontainer">
-    <div class="features-imagecontainer">
-      <img src="../../img/feature-images/feature-xml.png" alt="" class="features-featureimage"/>
-    </div>
-    <div class="features-textcontainer">
-      <h3 class="h3">Human-Readable Files</h3>
-      <p class="p-body">
-        All Natron files are saved as plaintext XML. While Natron's autosave feature is fairly robust, in dire situations broken comps can be recovered with your choice of text editor!
-      </p>
-    </div>
-  </div>
-</section>
+{% include feature-detail.html
+   title="Human-Readable Files"
+   img="../../img/feature-images/feature-xml.png"
+   img_alt="An image of a Natron project file open in a text editor"
+   justify="right"
+   detail="
+    All Natron files are saved as plaintext XML. While Natron's autosave feature is fairly robust, in dire situations broken comps can be recovered with your choice of text editor!"
+%}


### PR DESCRIPTION
This PR adds a Jekyll template for the feature descriptions, so that what used to be written like this:

```html
<section>
  <div class="features-featurecontainer">
    <div class="features-imagecontainer">
      <img src="https://picsum.photos/1280/720" alt="" class="features-featureimage"/>
    </div>
    <div class="features-textcontainer">
      <h3 class="h3">2D Tracking</h3>
      <p class="p-body">
        Track difficult movements with ease!
        <br />
        <br />
        Natron's tracker can handle and correct a variety of footage types with single
        point or perspective tracking. Luminance variation correction and manual
        keyframes ensure get solid tracks even in tricky shots.
      </p>
    </div>
  </div>
</section>
```

Becomes the much more easy-to-scan code:

```
{% include feature-detail.html
   title="2D Tracking"
   img="https://picsum.photos/1280/720"
   img_alt=""
   detail="
    Track difficult movements with ease!
    <br /><br />
    Natron's tracker can handle and correct a variety of footage types with single 
    point or perspective tracking. Luminance variation correction and manual 
    keyframes ensure get solid tracks even in tricky shots."
%}
```

In addition, the template supports setting the feature description text in **markdown** so that what previously looked like this:

```html
Natron is compliant with the OpenFX standard, allowing you to tap into the
vast ecosystem of commercial OFX plugins. Never worry about missing the
functionality of your OFX plugins, with Natron's support for <a
href="http://www.revisionfx.com" class="intext-link
intext-link-glow">RevisionFX products</a>, <a
href="https://www.neatvideo.com" class="intext-link
intext-link-glow">NeatVideo denoiser</a>, <a
href="http://www.thefoundry.co.uk/products/furnace/" class="intext-link
intext-link-glow">Furnace by The Foundry</a>, <a
href="http://www.thefoundry.co.uk/products/plugins/keylight/"
class="intext-link intext-link-glow">KeyLight</a>, <a
href="http://www.genarts.com/software/sapphire/overview" class="intext-link
intext-link-glow">GenArts Sapphire</a>, <a
href="http://www.redgiant.com/universe/" class="intext-link
intext-link-glow">Red Giant Universe</a>, <a
href="https://hitfilm.com/ignite" class="intext-link intext-link-glow">Ignite
by HitFilm</a>, and many more!
```

Now becomes this, which is much-more-readable:

```md
Natron is compliant with the OpenFX standard, allowing you to tap into the
vast ecosystem of commercial OFX plugins. Never worry about missing the
functionality of your OFX plugins, with Natron's support for
[RevisionFX products](http://www.revisionfx.com), [NeatVideo denoiser]
(https://www.neatvideo.com), [Furnace by The Foundry]
(http://www.thefoundry.co.uk/products/furnace/), [KeyLight]
(http://www.thefoundry.co.uk/products/plugins/keylight/), [GenArts Sapphire]
(http://www.genarts.com/software/sapphire/overview), [Red Giant Universe]
(http://www.redgiant.com/universe/), [Ignite by HitFilm]
(https://hitfilm.com/ignite), and many more!
```

Hope this makes editing the website easier and nicer!

> **Note:** The markdown within the blocks does need to be escaped properly. Specifically, double-quotes must be escaped (e.g. `\"...\"`) and empty newlines are not allowed, instead you should use `<br />` to create an effective empty newline.