### PR TITLE
Prevent GH actions from running on any other branch

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -17,6 +17,8 @@ jobs:
   # Build job
   build:
     runs-on: ubuntu-latest
+    # Run only on push to the `main` branch
+    if: github.ref == 'refs/heads/main'
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Currently GitHub actions runs on push to any branch which is a waste of resources. This PR makes sure that it only runs if the push is to `main`.